### PR TITLE
Delete Functionality

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,6 +35,13 @@ class ArticlesController < ApplicationController
     end
   end
 
+  def destroy
+    @article = Article.find(params[:id])
+    @article.destroy
+  
+    redirect_to root_path, status: :see_other
+  end
+
 
   private
   def article_params 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,6 +5,10 @@
 <p>Date: <%= @article.date %></p>
 <ul>
   <li><%= link_to "Edit", edit_article_path(@article) %></li>
+  <li><%= link_to "Delete", article_path(@article), data: {
+    turbo_method: :delete,
+    turbo_confirm: "Are you sure?"
+  } %></li>
   <li><%= link_to "Home", root_path %></li>
 </ul>
 

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -30,5 +30,13 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to article_path(@article)
     @article.reload
     assert_equal "updated", @article.title
+  end
+
+  test "should destroy article" do
+    assert_difference("Article.count", -1) do
+      delete article_url(@article)
     end
+  
+    assert_redirected_to root_path
+  end
 end


### PR DESCRIPTION
## Overview

This PR implements Delete functionality. Users are now able to delete a post. There is a confirmation request before deletion. occurs. Redirects user to home page (index).

- [x] implement delete controller
- [x] update show view with delete capabilities
- [x] pass model and controller delete tests

## Demo
![deleteDemoShopify_](https://github.com/mkudrenecky/eng-intern-assessment-rails/assets/112984152/8bd15a85-f413-4e95-bca8-584b36c3b2e9)

